### PR TITLE
recalc user statistics using sql

### DIFF
--- a/app/repositories/stats.py
+++ b/app/repositories/stats.py
@@ -310,19 +310,19 @@ UPDATE stats s
 INNER JOIN concrete_stats cs ON 1
 INNER JOIN calculated c ON 1
 SET
-    s.tscore = cs.total_score,
-    s.rscore = cs.ranked_score,
-    s.pp = c.pp,
-    s.acc = c.acc,
-    s.plays = cs.count,
-    s.playtime = cs.play_time,
-    s.max_combo = cs.max_combo,
-    s.total_hits = cs.total_hits,
-    s.xh_count = cs.xh_count,
-    s.x_count = cs.x_count,
-    s.sh_count = cs.sh_count,
-    s.s_count = cs.s_count,
-    s.s_count = cs.a_count
+    s.tscore = COALESCE(cs.total_score, 0),
+    s.rscore = COALESCE(cs.ranked_score, 0),
+    s.pp = COALESCE(c.pp, 0),
+    s.acc = COALESCE(c.acc, 0),
+    s.plays = COALESCE(cs.count, 0),
+    s.playtime = COALESCE(cs.play_time, 0),
+    s.max_combo = COALESCE(cs.max_combo, 0),
+    s.total_hits = COALESCE(cs.total_hits, 0),
+    s.xh_count = COALESCE(cs.xh_count, 0),
+    s.x_count = COALESCE(cs.x_count, 0),
+    s.sh_count = COALESCE(cs.sh_count, 0),
+    s.s_count = COALESCE(cs.s_count, 0),
+    s.a_count = COALESCE(cs.a_count, 0)
 WHERE s.id = :user_id AND s.mode = :mode
     """
 

--- a/app/repositories/stats.py
+++ b/app/repositories/stats.py
@@ -302,7 +302,7 @@ async def sql_recalculate_mode(player_id: int, mode: int) -> None:
             SUM(s2.grade = "A") AS a_count
         FROM
             scores s2
-        INNER JOIN maps m2 ON s2.map_md5 = m2.md5
+        LEFT JOIN maps m2 ON s2.map_md5 = m2.md5
         WHERE s2.mode = :mode
         AND s2.userid = :user_id
     )

--- a/app/repositories/stats.py
+++ b/app/repositories/stats.py
@@ -235,6 +235,8 @@ async def partial_update(
 
 
 async def sql_recalculate_mode(player_id: int, mode: int) -> None:
+    # https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score
+    # The ranked score is the total sum of the *best scores* for all ranked, loved, and approved difficulties played online.
     sql = f"""
     WITH 
     ordered_pp AS (
@@ -289,7 +291,7 @@ async def sql_recalculate_mode(player_id: int, mode: int) -> None:
         SELECT
             COUNT(*) AS count,
             SUM(s2.score) AS total_score,
-            SUM(IF(s2.status IN (2, 3), s2.score, 0)) AS ranked_score,
+            SUM(IF(m2.status IN (2, 3) AND s2.status = 2, s2.score, 0)) AS ranked_score,
             SUM(s2.n300 + s2.n100 + s2.n50 + (IF(s2.mode IN (1, 3, 5), s2.ngeki + s2.nkatu, 0))) AS total_hits,
             SUM(s2.time_elapsed) / 1000 AS play_time,
             MAX(s2.max_combo) AS max_combo,  


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
- recalc user statistics using sql
we are running this code for few months, and eliminated few bugs during testing.

- atomic updates on beatmap statistics
I don't feel boatmap play count needs to be accurate but if needed we can also count from submitted scores.

### benefits
- will dramatically speed up score submission.
for our server (ppy.sb), in extreme cases (multiplay, multiple user, heavy user), user will experience score submission speed up from few minutes to seconds.
I believe this change could also in theory make removing the implemented global submission lock possible, therefore further increase parallel performance for multiple user submitting scores.
Such lock is for prevent increasing user stat twice for same score, bpy will / should check checksum to not allow multiple same score inserted into db. 


- handles db changes naturally.
other than using our recalc utils (mentioned below), all stats will be updated after user submit any score, if proceed any database modifications eg. delete score, rank custom maps, recalc score stats.


I believe some sort of indexes are required for the calculation to run smoothly.
we have 2 compound indexes: 
- `map-leaderboard (map_md5, mode, status)` 
- `user-best (userid, mode, status, pp)` 

these are for both recalc and our frontend.

```sql
CREATE INDEX `map-leaderboard` ON `scores` (`map_md5`,`mode`,`status`);--> statement-breakpoint
CREATE INDEX `user-best` ON `scores` (`userid`,`mode`,`status`,`pp`);--> statement-breakpoint
```

## Related Issues / Projects
we also have offline recalc utility if anything messed up:
https://github.com/ppy-sb/nyamatrix


## Checklist
- [x] I've manually tested my code
