### PR TITLE
check user in a match before allowing match creation

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1413,6 +1413,21 @@ class MatchCreate(BasePacket):
             player.enqueue(app.packets.match_join_fail())
             return
 
+        if player.match:
+            player.enqueue(app.packets.match_join_fail())
+            player.send_bot("You're already in a match. We will try removing you from it.")
+
+            async def next_tick():
+                player.leave_match()
+                player.enqueue(
+                    app.packets.notification(
+                        "You can try again. Please report to staff if you keep getting this error."
+                    )
+                )
+
+            asyncio.create_task(next_tick(), name="remove-duplicated-user")
+            return
+
         # create the channel and add it
         # to the global channel list as
         # an instanced channel.

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -662,16 +662,17 @@ class Player:
             return
 
         slot = self.match.get_slot(self)
-        assert slot is not None
-
-        if slot.status == SlotStatus.locked:
-            # player was kicked, keep the slot locked.
-            new_status = SlotStatus.locked
+        if slot is None:
+            log(f"{self} tried leaving a match without its slot?", Ansi.LYELLOW)
         else:
-            # player left, open the slot for new players to join.
-            new_status = SlotStatus.open
+            if slot.status == SlotStatus.locked:
+                # player was kicked, keep the slot locked.
+                new_status = SlotStatus.locked
+            else:
+                # player left, open the slot for new players to join.
+                new_status = SlotStatus.open
 
-        slot.reset(new_status=new_status)
+            slot.reset(new_status=new_status)
 
         self.leave_channel(self.match.chat)
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
We've been hunting this bug for very long time: our server will occasionally have ghost rooms with no one inside.
in our c.ppy.sb we have a [HTML page](https://c.ppy.sb/matches) showing all matches (slightly different from akat bpy one also by me lol), which will also fail, due to "Internal server error".
until yesterday I found this:
<img width="992" height="129" alt="image" src="https://github.com/user-attachments/assets/134816ac-7a8a-41dd-9055-18ecec1b5760" />
two room have same host.

I am taking a guess here:
user somehow got inside multiple room, probably due to `PART_MATCH` packet was never received, then create or join new match.
then user logout, bpy user logout handler calls `self.leave_match()`
`self.leave_match()` uses self.match to remove user from one match, then removed user from object cache
the another room still contains the userid, 
thus when I check our web page, `host` getter will fail due to ValueError raised.
and due to slot still contains user reference, a match in this state never truly terminated & recycled.

this pr adds the boundary check when user creating a new match.
we have similar check in `join_match`.

this pr will only work if player.match still holds the match. If somehow Player.match was reset from user object similar problem still gonna happen.
Ultimately if we want to do defensive programming we should instead walk through all matches and slots to do the cleanup.
I will consider above if it still fails preventing this invalid state from happening.


## Related Issues / Projects

## Checklist
- [ ] I've manually tested my code
(still collecting data from our prod)
